### PR TITLE
Pharo8 and 9 fixes

### DIFF
--- a/src/OSProcess-Base/AbstractBinaryFileStream.extension.st
+++ b/src/OSProcess-Base/AbstractBinaryFileStream.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #AbstractBinaryFileStream }
+
+{ #category : #'*OSProcess-Base' }
+AbstractBinaryFileStream >> fileID [
+	^ handle
+]

--- a/src/OSProcess-Tests/AioEventHandlerTestCase.class.st
+++ b/src/OSProcess-Tests/AioEventHandlerTestCase.class.st
@@ -4,15 +4,33 @@ Test AioEventHandler and AioPlugin. Provides fair coverage of IO readable events
 Class {
 	#name : #AioEventHandlerTestCase,
 	#superclass : #TestCase,
+	#instVars : [
+		'temporaryFileStream'
+	],
 	#category : #'OSProcess-Tests'
 }
+
+{ #category : #running }
+AioEventHandlerTestCase >> tearDown [
+	temporaryFileStream ifNotNil: [
+		temporaryFileStream close.
+		temporaryFileStream file delete ].
+	
+	super tearDown
+]
+
+{ #category : #accessing }
+AioEventHandlerTestCase >> temporaryFileStream [
+	^ temporaryFileStream ifNil: [
+		temporaryFileStream := (FileLocator temp / UUID new asString) unbufferedBinaryWriteStream ].
+]
 
 { #category : #testing }
 AioEventHandlerTestCase >> testEnableHandleAndDisable [
 
 	| eventHandler anOpenFile fileHandle aioHandleResult sema semaIndex aioEnableResult aioDisableResult |
 	eventHandler := AioEventHandler new.
-	anOpenFile := SourceFiles at: 1.
+	anOpenFile := self temporaryFileStream.
 	fileHandle := eventHandler handleForFile: anOpenFile.
 	sema := Semaphore new.
 	[semaIndex := Smalltalk registerExternalObject: sema.
@@ -229,7 +247,7 @@ AioEventHandlerTestCase >> testHandleForFile [
 
 	| eventHandler anOpenFile fileHandle |
 	eventHandler := AioEventHandler new.
-	anOpenFile := SourceFiles at: 1.
+	anOpenFile := self temporaryFileStream.
 	fileHandle := eventHandler handleForFile: anOpenFile.
 	self assert: fileHandle notNil.
 	self assert: (fileHandle isKindOf: Integer)


### PR DESCRIPTION
Added `#fileID` extension to AbstractBinaryFileStream so that it's possible again to supply the descriptors array without having to use the deprecated streams.

Also fixed two tests.

There are still some things that don't work but they haven't had any impact on my work so far so I didn't spend time to look into the test failures.