### PR TITLE
Add dependency to DeprecatedFileStream package for Pharo 9.x.

### DIFF
--- a/src/BaselineOfOSProcess/BaselineOfOSProcess.class.st
+++ b/src/BaselineOfOSProcess/BaselineOfOSProcess.class.st
@@ -6,14 +6,20 @@ Class {
 
 { #category : #baselines }
 BaselineOfOSProcess >> baseline: spec [
-	<baseline>
 
-	spec for: #common do: [ 
-		spec postLoadDoIt: #'postload:package:'.
+	<baseline>
+	spec for: #common do: [ self baselineForCommon: spec ].
+	spec for: #'pharo9.x' do: [ self baselineForPharo9: spec ]
+]
+
+{ #category : #baselines }
+BaselineOfOSProcess >> baselineForCommon: spec [
+
+spec postLoadDoIt: #postload:package:.
 		spec baseline: 'CommandShell' with: [ 
-			spec 
+			spec
 				repository: 'github://dtlewis290/CommandShell-Tonel/src';
-				loads: #('Piping') ].
+				loads: #( 'Piping' ) ].
 
 		spec
 			package: 'OSProcess-Base';
@@ -26,13 +32,25 @@ BaselineOfOSProcess >> baseline: spec [
 			package: 'OSProcess-Win32'.
 
 		spec
-			group: 'Core' with: #('OSProcess-Base' 'OSProcess-AIO' 'OSProcess-Mac' 'OSProcess-Unix' 'OSProcess-Win32');
-			group: 'Core with Output' with: #('Core' 'CommandShell');
-			group: 'OS2' with: #('Core' 'OSProcess-OS2');
-			group: 'RiscOS' with: #('Core' 'OSProcess-RiscOS');
-			group: 'Tests' with: #('Core' 'OSProcess-Tests');
-			group: 'default' with: #('Tests').
-		 ]
+			group: 'Core'
+			with:
+				#( 'OSProcess-Base' 'OSProcess-AIO' 'OSProcess-Mac'
+				   'OSProcess-Unix' 'OSProcess-Win32' );
+			group: 'Core with Output' with: #( 'Core' 'CommandShell' );
+			group: 'OS2' with: #( 'Core' 'OSProcess-OS2' );
+			group: 'RiscOS' with: #( 'Core' 'OSProcess-RiscOS' );
+			group: 'Tests' with: #( 'Core' 'OSProcess-Tests' );
+			group: 'default' with: #( 'Tests' )
+]
+
+{ #category : #baselines }
+BaselineOfOSProcess >> baselineForPharo9: spec [
+
+	spec
+		baseline: 'DeprecatedFileStream'
+		with: [ 
+		spec repository: 'github://luque/DeprecatedFileStream:main/src' ].
+	self baselineForCommon: spec
 ]
 
 { #category : #actions }


### PR DESCRIPTION
Trying a temporal workaround to the issue #2 adding the DeprecatedFileStream package as dependency when the project is loaded on Pharo 9.x images.